### PR TITLE
Fix disk path

### DIFF
--- a/Source/DiskCache.swift
+++ b/Source/DiskCache.swift
@@ -67,7 +67,7 @@ class DiskCache {
             stored.
     */
     init(path: String?, searchPathDirectory: NSSearchPathDirectory, maxCacheSize: Int) {
-        self.path = path ?? "mattress"
+        self.path = path ?? "mattress/"
         self.searchPathDirectory = searchPathDirectory
         self.maxCacheSize = maxCacheSize
         loadPropertiesFromDisk()


### PR DESCRIPTION
Looks like there was a trailing slash missing that was causing all files to be stored in the root Documents directory.

Per issue https://github.com/buzzfeed/mattress/issues/33.

@dmauro 