### PR TITLE
Fix absolute file path error in `DiskCache` - Swift 2.3

### DIFF
--- a/Source/DiskCache.swift
+++ b/Source/DiskCache.swift
@@ -452,10 +452,10 @@ class DiskCache {
         if let
             baseURL = baseURL,
             fileURL = NSURL(string: path, relativeToURL: baseURL),
-            absFilePath = fileURL.absoluteString
+            absoluteFilePath = fileURL.absoluteString
         {
             var isDir : ObjCBool = false
-            if !NSFileManager.defaultManager().fileExistsAtPath(absFilePath, isDirectory: &isDir) {
+            if !NSFileManager.defaultManager().fileExistsAtPath(absoluteFilePath, isDirectory: &isDir) {
                 do {
                     try NSFileManager.defaultManager().createDirectoryAtURL(fileURL,
                         withIntermediateDirectories: true, attributes: nil)

--- a/Source/DiskCache.swift
+++ b/Source/DiskCache.swift
@@ -451,10 +451,11 @@ class DiskCache {
         var url: NSURL?
         if let
             baseURL = baseURL,
-            fileURL = NSURL(string: path, relativeToURL: baseURL)
+            fileURL = NSURL(string: path, relativeToURL: baseURL),
+            absFilePath = fileURL.absoluteString
         {
             var isDir : ObjCBool = false
-            if !NSFileManager.defaultManager().fileExistsAtPath(fileURL.absoluteString, isDirectory: &isDir) {
+            if !NSFileManager.defaultManager().fileExistsAtPath(absFilePath, isDirectory: &isDir) {
                 do {
                     try NSFileManager.defaultManager().createDirectoryAtURL(fileURL,
                         withIntermediateDirectories: true, attributes: nil)


### PR DESCRIPTION
Added the absolute file path as a separate variable in the `let`
expression so its value can be safely unwrapped and used within
`NSFileManager.fileExistsAtPath(...)` (in order for Mattress to compile
properly in Swift 2.3).